### PR TITLE
Request for comments: Removing repetitive bower version message on deploy.

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -585,10 +585,9 @@ ERROR
   # install bower as npm module
   def install_bower
     log("bower") do
-      topic "Using bower version: #{BOWER_VERSION}"
       run("curl #{BOWER_BASE_URL}/bower-#{BOWER_VERSION}/node_modules.tar.gz -s -o - | tar xzf -")
       unless $?.success?
-        error "Can't install bower"
+        error "Can't install bower #{BOWER_VERSION}"
       end
     end
   end


### PR DESCRIPTION
When building the application the following messages appear:

-----> Writing config/database.yml to read from DATABASE_URL
-----> Using bower version: 1.2.7
-----> Installing JavaScript dependencies using bower 1.2.7

There is an unecessary repetition on bower version, this removes this
message, like:

-----> Writing config/database.yml to read from DATABASE_URL
-----> Installing JavaScript dependencies using bower 1.2.7
