### PR TITLE
Request for comments: Removing repetitive bower version message on deploy.

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -585,10 +585,9 @@ ERROR
   # install bower as npm module
   def install_bower
     log("bower") do
-      topic "Using bower version: #{BOWER_VERSION}"
       run("curl #{BOWER_BASE_URL}/bower-#{BOWER_VERSION}/node_modules.tar.gz -s -o - | tar xzf -")
       unless $?.success?
-        error "Can't install bower"
+        error "Can't install Bower #{BOWER_VERSION}"
       end
     end
   end
@@ -607,14 +606,14 @@ Check these points:
 ERROR
 
     log("bower") do
-      topic("Installing JavaScript dependencies using bower #{BOWER_VERSION}")
+      topic("Installing JavaScript dependencies using Bower #{BOWER_VERSION}")
 
       load_bower_cache
 
       pipe("./node_modules/bower/bin/bower install --config.storage.packages=vendor/bower/packages --config.storage.registry=vendor/bower/registry --config.tmp=vendor/bower/tmp 2>&1")
       if $?.success?
         log "bower", :status => "success"
-        puts "Cleaning up the bower tmp."
+        puts "Cleaning up the Bower tmp."
         FileUtils.rm_rf("vendor/bower/tmp")
         cache.store "vendor/bower"
       else


### PR DESCRIPTION
When building the application the following messages appear:

-----> Writing config/database.yml to read from DATABASE_URL
-----> Using bower version: 1.2.7
-----> Installing JavaScript dependencies using bower 1.2.7

There is an unecessary repetition on bower version, this removes this
message, like:

-----> Writing config/database.yml to read from DATABASE_URL
-----> Installing JavaScript dependencies using Bower 1.2.7
