### PR TITLE
Update Bower to 1.2.8 and upstream to v85

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
 before_script: bundle exec rake hatchet:setup_travis
 
 # Run tests in parallel
-script: bundle exec parallel_rspec -n 7 spec/
+script: bundle exec parallel_rspec -n 11 spec/
 
 after_script:
   - heroku keys:remove ~/.ssh/id_rsa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,26 @@
 ## Master
 
+
+## v85 (12/05/2012)
+
+Features:
+
+
+Bugfixes:
+
+* Any errors in a Rakefile will now be explicitly shown as such instead of hidden in a `assets:precompile` task detection failure (#171)
+* Now using correct default "hobby" database #179
+
 ## v84 (11/06/2013)
+
+Features:
+
+* Any Ruby app with a rake `assets:precompile` task present that does not run successfully will now fail. This matches the current behavior of Rails 3 and 4 deploys.
+
 
 Bugfixes:
 
 * Fix default gem cache
-
 
 ## v83 (10/29/2013)
 

--- a/hatchet.json
+++ b/hatchet.json
@@ -1,4 +1,10 @@
 {
+  "rake": [
+    "sharpstone/asset_precompile_fail",
+    "sharpstone/asset_precompile_pass",
+    "sharpstone/asset_precompile_not_found",
+    "sharpstone/bad_rakefile"
+  ],
   "bundler": [
     "sharpstone/bad_gemfile_on_platform",
     "sharpstone/git_gemspec",

--- a/lib/language_pack.rb
+++ b/lib/language_pack.rb
@@ -1,4 +1,5 @@
 require "pathname"
+require 'benchmark'
 
 # General Language Pack module
 module LanguagePack
@@ -26,9 +27,11 @@ end
 $:.unshift File.expand_path("../../vendor", __FILE__)
 
 require 'dotenv'
+require 'language_pack/shell_helpers'
 require 'language_pack/instrument'
 require "language_pack/helpers/plugin_installer"
 require "language_pack/helpers/stale_file_cleaner"
+require "language_pack/helpers/rake_runner"
 require "language_pack/ruby"
 require "language_pack/rack"
 require "language_pack/rails2"

--- a/lib/language_pack/helpers/rake_runner.rb
+++ b/lib/language_pack/helpers/rake_runner.rb
@@ -1,0 +1,117 @@
+class LanguagePack::Helpers::RakeRunner
+  include LanguagePack::ShellHelpers
+
+  class RakeTask
+    ALLOWED = [:pass, :fail, :no_load, :not_found]
+    include LanguagePack::ShellHelpers
+
+    attr_accessor :output, :time, :command, :status, :task_defined, :rakefile_can_load
+
+    alias :rakefile_can_load? :rakefile_can_load
+    alias :task_defined?      :task_defined
+    alias :is_defined?        :task_defined
+
+    def initialize(task, command = nil)
+      @task    = task
+      command  = "env PATH=$PATH:bin bundle exec rake #{task} 2>&1" if command.nil?
+      raise "expect #{command} to contain #{task}" unless command.include?(task)
+
+      @command = command
+      @status  = :nil
+      @output  = ""
+    end
+
+    def success?
+      status == :pass
+    end
+
+    def status?
+      @status && @status != :nil
+    end
+
+    def status
+      raise "Status not set for #{self.inspect}" if @status == :nil
+      raise "Not allowed status: #{@status} for #{self.inspect}" unless ALLOWED.include?(@status)
+      @status
+    end
+
+    def invoke(cmd = nil)
+      cmd = cmd || @command
+      puts "Running: rake #{@task}"
+      time = Benchmark.realtime do
+        self.output = pipe(cmd)
+      end
+      self.time = time
+
+      if $?.success?
+        self.status = :pass
+      else
+        self.status = :fail
+      end
+      return self
+    end
+  end
+
+  def initialize(has_rake = true)
+    @has_rake = has_rake
+    if has_rake
+      load_rake_tasks
+    else
+      @rake_tasks    = ""
+      @rakefile_can_load = false
+    end
+  end
+
+  def cannot_load_rakefile?
+    !rakefile_can_load?
+  end
+
+  def rakefile_can_load?
+    @rakefile_can_load
+  end
+
+  def instrument(*args, &block)
+    LanguagePack::Instrument.instrument(*args, &block)
+  end
+
+  def load_rake_tasks
+    instrument "ruby.rake_task_defined" do
+      @rake_tasks        ||= run("env PATH=$PATH bundle exec rake -P --trace")
+      @rakefile_can_load ||= $?.success?
+      @rake_tasks
+    end
+  end
+
+  def load_rake_tasks!
+    out =  load_rake_tasks
+    msg =  "Could not detect rake tasks\n"
+    msg << "ensure you can run `$ bundle exec rake -P` against your app with no environment variables present\n"
+    msg << "and using the production group of your Gemfile.\n"
+    msg << "This may be intentional, if you expected rake tasks to be run\n"
+    msg << "cancel the build (CTRL+C) and fix the error then commit the fix:\n"
+    msg << out
+    puts msg if cannot_load_rakefile?
+    return self
+  end
+
+  def task_defined?(task)
+    return false if cannot_load_rakefile?
+    @task_available ||= Hash.new {|hash, key| hash[key] = @rake_tasks.match(/\s#{key}\s/) }
+    @task_available[task]
+  end
+
+  def not_found?(task)
+    !task_defined?(task)
+  end
+
+  def task(rake_task, command = nil)
+    t = RakeTask.new(rake_task, command)
+    t.task_defined      = task_defined?(rake_task)
+    t.rakefile_can_load = rakefile_can_load?
+    t
+  end
+
+  def invoke(task, command = nil)
+    self.task(task, command).invoke
+  end
+end

--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -59,7 +59,9 @@ private
     instrument "rails3.run_assets_precompile_rake_task" do
       log("assets_precompile") do
         setup_database_url_env
-        return true unless rake_task_defined?("assets:precompile")
+
+        precompile = rake.task("assets:precompile")
+        return true unless precompile.is_defined?
 
         topic("Preparing app for Rails asset pipeline")
         if File.exists?("public/assets/manifest.yml")
@@ -72,11 +74,11 @@ private
 
         puts "Running: rake assets:precompile"
         require 'benchmark'
-        time = Benchmark.realtime { pipe("env PATH=$PATH:bin bundle exec rake assets:precompile 2>&1") }
 
-        if $?.success?
+        precompile.invoke
+        if precompile.success?
           log "assets_precompile", :status => "success"
-          puts "Asset precompilation completed (#{"%.2f" % time}s)"
+          puts "Asset precompilation completed (#{"%.2f" % precompile.time}s)"
         else
           log "assets_precompile", :status => "failure"
           error "Precompiling assets failed."

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -73,7 +73,8 @@ WARNING
       log("assets_precompile") do
         setup_database_url_env
 
-        return true unless rake_task_defined?("assets:precompile")
+        precompile = rake.task("assets:precompile")
+        return true unless precompile.is_defined?
 
         if Dir.glob('public/assets/manifest-*.json').any?
           puts "Detected manifest file, assuming assets were compiled locally"
@@ -87,13 +88,11 @@ WARNING
         @cache.load public_assets_folder
         @cache.load default_assets_cache
 
-        puts "Running: rake assets:precompile"
-        require 'benchmark'
-        time = Benchmark.realtime { pipe("env PATH=$PATH:bin bundle exec rake assets:precompile 2>&1 > /dev/null") }
+        precompile.invoke
 
-        if $?.success?
+        if precompile.success?
           log "assets_precompile", :status => "success"
-          puts "Asset precompilation completed (#{"%.2f" % time}s)"
+          puts "Asset precompilation completed (#{"%.2f" % precompile.time}s)"
 
           puts "Cleaning assets"
           pipe "env PATH=$PATH:bin bundle exec rake assets:clean 2>& 1"

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -394,8 +394,8 @@ WARNING
     instrument 'ruby.install_language_pack_gems' do
       FileUtils.mkdir_p(slug_vendor_base)
       Dir.chdir(slug_vendor_base) do |dir|
-        gems.each do |gem|
-          @fetchers[:buildpack].fetch_untar("#{gem}.tgz")
+        gems.each do |g|
+          @fetchers[:buildpack].fetch_untar("#{g}.tgz")
         end
         Dir["bin/*"].each {|path| run("chmod 755 #{path}") }
       end
@@ -713,13 +713,8 @@ params = CGI.parse(uri.query || "")
     bundle.specs.map(&:name).include?(gem)
   end
 
-  # detects if a rake task is defined in the app
-  # @param [String] the task in question
-  # @return [Boolean] true if the rake task is defined in the app
-  def rake_task_defined?(task)
-    instrument "ruby.rake_task_defined" do
-      run("env PATH=$PATH bundle exec rake #{task} --dry-run") && $?.success?
-    end
+  def rake
+    @rake ||= LanguagePack::Helpers::RakeRunner.new(gem_is_bundled?("rake")).load_rake_tasks!
   end
 
   # executes the block with GIT_DIR environment variable removed since it can mess with the current working directory git thinks it's in
@@ -745,13 +740,17 @@ params = CGI.parse(uri.query || "")
 
   def run_assets_precompile_rake_task
     instrument 'ruby.run_assets_precompile_rake_task' do
-      if rake_task_defined?("assets:precompile")
 
-        topic "Running: rake assets:precompile"
-        time = Benchmark.realtime { pipe("env PATH=$PATH:bin bundle exec rake assets:precompile 2>&1") }
-        if $?.success?
-          puts "Asset precompilation completed (#{"%.2f" % time}s)"
-        end
+      precompile = rake.task("assets:precompile")
+      return true unless precompile.is_defined?
+
+      topic "Running: rake assets:precompile"
+      precompile.invoke
+      if precompile.success?
+        puts "Asset precompilation completed (#{"%.2f" % precompile.time}s)"
+      else
+        log "assets_precompile", :status => "failure"
+        error "Precompiling assets failed."
       end
     end
   end

--- a/spec/helpers/rake_runner_spec.rb
+++ b/spec/helpers/rake_runner_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe "Rake Runner" do
+  it "runs rake tasks that exist" do
+    Hatchet::App.new('asset_precompile_pass').in_directory do
+      rake = LanguagePack::Helpers::RakeRunner.new.load_rake_tasks!
+      task = rake.task("assets:precompile")
+      task.invoke
+
+      expect(task.status).to   eq(:pass)
+      expect(task.output).to   match("success!")
+      expect(task.time).not_to be_nil
+    end
+  end
+
+  it "detects when rake tasks fail" do
+    Hatchet::App.new('asset_precompile_fail').in_directory do
+      rake = LanguagePack::Helpers::RakeRunner.new.load_rake_tasks!
+      task = rake.task("assets:precompile")
+      task.invoke
+
+      expect(task.status).to   eq(:fail)
+      expect(task.output).to   match("assets:precompile fails")
+      expect(task.time).not_to be_nil
+    end
+  end
+
+  it "can show errors from bad Rakefiles" do
+    Hatchet::App.new('bad_rakefile').in_directory do
+      rake = LanguagePack::Helpers::RakeRunner.new.load_rake_tasks!
+      task = rake.task("assets:precompile")
+      expect(rake.rakefile_can_load?).to be_false
+      expect(task.task_defined?).to      be_false
+    end
+  end
+
+  it "detects if task is missing" do
+    Hatchet::App.new('asset_precompile_not_found').in_directory do
+      task = LanguagePack::Helpers::RakeRunner.new.task("assets:precompile")
+      expect(task.task_defined?).to be_false
+    end
+  end
+end


### PR DESCRIPTION
Update Bower to 1.2.8 and upstream code to v85.

```
Bugfixes:

* Any errors in a Rakefile will now be explicitly shown as such instead of hidden in a assets:precompile task detection failure (#171)
* Now using correct default "hobby" database #179
```
- [heroku-buildpack-ruby/CHANGELOG.md at 55ff6dd8e845f54943f4083185e009f1d0a144a5 · heroku/heroku-buildpack-ruby](https://github.com/heroku/heroku-buildpack-ruby/blob/55ff6dd8e845f54943f4083185e009f1d0a144a5/CHANGELOG.md#v85-12052013)
