### PR TITLE
[TEMP] Disable caching bower packages and registry

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -602,15 +602,8 @@ ERROR
     log("bower") do
       topic("Installing JavaScript dependencies using Bower #{BOWER_VERSION}")
 
-      load_bower_cache
-
-      pipe("./node_modules/bower/bin/bower install --config.storage.packages=vendor/bower/packages --config.storage.registry=vendor/bower/registry --config.tmp=vendor/bower/tmp 2>&1")
-      if $?.success?
-        log "bower", :status => "success"
-        puts "Cleaning up the Bower tmp."
-        FileUtils.rm_rf("vendor/bower/tmp")
-        cache.store "vendor/bower"
-      else
+      pipe("./node_modules/bower/bin/bower install 2>&1")
+      unless $?.success?
         error error_message
       end
     end


### PR DESCRIPTION
Disable caching bower packages and registry temporarily.
This is a workaround for https://github.com/bower/bower/issues/933.

Use this branch, if you faced a heroku deployment error looks like this:

```
       bower jquery#>= 1.7.1        ENOTEMPTY ENOTEMPTY, rename 'vendor/bower/tmp/jquery-1435-FddgpL'
       Stack trace:
       Error: ENOTEMPTY, rename 'vendor/bower/tmp/jquery-1435-FddgpL'
```

How to use:

``` shell
$ heroku config:set -a YOUR_APP_NAME \
  BUILDPACK_URL='git://github.com/qnyp/heroku-buildpack-ruby-bower.git#workaround-for-bower-cache-bug'
```

I'll keep this branch till bower fixes problem.
