### PR TITLE
Add support to specify bower version via BOWER_ENV

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -21,7 +21,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   LEGACY_JVM_VERSION   = "openjdk1.7.0_25"
   DEFAULT_RUBY_VERSION = "ruby-2.0.0"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
-  BOWER_VERSION        = user_env_hash['BOWER_VERSION'] || "1.3.1-patched"
+  BOWER_VERSION        = "1.3.1-patched"
   BOWER_BASE_URL       = "http://heroku-buildpack-ruby-bower.s3.amazonaws.com"
   NODE_JS_VERSION      = "0.10.21"
   NODE_JS_BASE_URL     = "http://heroku-buildpack-nodejs.s3.amazonaws.com"
@@ -587,9 +587,9 @@ ERROR
   # install bower as npm module
   def install_bower
     log("bower") do
-      run("curl #{BOWER_BASE_URL}/bower-#{BOWER_VERSION}/node_modules.tar.gz -s -o - | tar xzf -")
+      run("curl #{BOWER_BASE_URL}/bower-#{bower_version}/node_modules.tar.gz -s -o - | tar xzf -")
       unless $?.success?
-        error "Can't install Bower #{BOWER_VERSION}. You can specify the version listed on http://heroku-buildpack-ruby-bower.s3-website-us-east-1.amazonaws.com/"
+        error "Can't install Bower #{bower_version}. You can specify the version listed on http://heroku-buildpack-ruby-bower.s3-website-us-east-1.amazonaws.com/"
       end
     end
   end
@@ -608,13 +608,17 @@ Check these points:
 ERROR
 
     log("bower") do
-      topic("Installing JavaScript dependencies using Bower #{BOWER_VERSION}")
+      topic("Installing JavaScript dependencies using Bower #{bower_version}")
 
       pipe("./node_modules/bower/bin/bower install --production")
       unless $?.success?
         error error_message
       end
     end
+  end
+
+  def bower_version
+    env('BOWER_VERSION') || BOWER_VERSION
   end
 
   # RUBYOPT line that requires syck_hack file


### PR DESCRIPTION
Now, you can specify bower version to install.

``` console
$ heroku config:set BOWER_VERSION=1.3.1
$ git push heroku master
Fetching repository, done.
Counting objects: 1, done.
Writing objects: 100% (1/1), 200 bytes | 0 bytes/s, done.
Total 1 (delta 0), reused 0 (delta 0)

-----> Deleting 3 files matching .slugignore patterns.
-----> Fetching custom git buildpack... done
-----> Ruby app detected
-----> Compiling Ruby/Rails
-----> Using Ruby version: ruby-2.1.1
-----> Installing dependencies using 1.5.2
(snip)
-----> Writing config/database.yml to read from DATABASE_URL
-----> Using Node.js version: 0.10.21
-----> Installing JavaScript dependencies using Bower 1.3.1
(snip)
```

Specifiable bower versions are listed on http://heroku-buildpack-ruby-bower.s3-website-us-east-1.amazonaws.com/ .

Close #21 
