### PR TITLE
Make env vars avaialble to shelled out commands

### DIFF
--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -37,6 +37,7 @@ module LanguagePack
           key   = file.basename.to_s
           value = file.read.strip
           user_env_hash[key] = value unless blacklist?(key)
+          ENV[key] = value unless blacklist?(key)
         end
       end
     end


### PR DESCRIPTION
Commands that are shelled out to do not have access to the environment variables currently, as they are only set in an internal hash.

This is a problem in my case, as I rely on having a FURY_TOKEN set for the fury-bower-resolver when bower runs.
